### PR TITLE
Feat/expose site key

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,16 @@ Add the following tag to your form where you’d like the reCAPTCHA to be displa
 {{ craft.recaptcha.render() }}
 ```
 
+You can also create the reCAPTCHA element yourself using the `sitekey` template variable. This is especially useful for implementing invisible recaptcha
+
+```twig
+<div class="g-recaptcha"
+      data-sitekey="{{ craft.recaptcha.sitekey }}"
+      data-callback="onSubmit"
+      data-size="invisible">
+</div>
+```
+
+
+
 Brought to you by [Matt West](https://mattwest.io)

--- a/src/variables/CraftRecaptchaVariable.php
+++ b/src/variables/CraftRecaptchaVariable.php
@@ -43,4 +43,11 @@ class CraftRecaptchaVariable
     {
       return CraftRecaptcha::$plugin->craftRecaptchaService->render();
     }
+
+    public function sitekey()
+    {
+      $settings = CraftRecaptcha::$plugin->getSettings();
+
+      return $settings->attributes['siteKey'];
+    }
 }


### PR DESCRIPTION
User's may need to change the markup of the actual reCAPTCHA element for things like invisible reCAPTCHA. This PR adds a template variable for accessing the sitekey and adds an example to the README of how it could be used