### PR TITLE
Add support for user registration forms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.0 - 2019-03-08
+### Added
+- Can now automatically verify user registration forms
+
 ## 1.0.1 - 2018-06-01
 ### Added
 - The Craft [contact form](https://github.com/craftcms/contact-form) plugin is no longer required.

--- a/src/CraftRecaptcha.php
+++ b/src/CraftRecaptcha.php
@@ -25,7 +25,7 @@ use craft\events\RegisterUrlRulesEvent;
 use craft\contactform\models\Submission;
 
 use craft\elements\User;
-use \craft\services\Elements;
+use craft\services\Elements;
 use craft\events\ElementEvent;
 
 use yii\base\Event;

--- a/src/config.php
+++ b/src/config.php
@@ -27,6 +27,6 @@ return [
     "siteKey" => "",
     "secretKey" => "",
     "validateContactForm" => true,
-    "validateUserRegistrationForm" => true,
+    "validateUserRegistrationForm" => false,
     
 ];

--- a/src/config.php
+++ b/src/config.php
@@ -27,5 +27,6 @@ return [
     "siteKey" => "",
     "secretKey" => "",
     "validateContactForm" => true,
+    "validateUserRegistrationForm" => true,
     
 ];

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -60,7 +60,7 @@ class Settings extends Model
      *
      * @var bool
      */
-    public $validateUserRegistrationForm= true;
+    public $validateUserRegistrationForm = false;
 
     // Public Methods
     // =========================================================================

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -55,6 +55,13 @@ class Settings extends Model
      */
     public $validateContactForm = true;
 
+    /**
+     * Validate User registration form submissions
+     *
+     * @var bool
+     */
+    public $validateUserRegistrationForm= true;
+
     // Public Methods
     // =========================================================================
 

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -43,3 +43,11 @@
     name: 'validateContactForm',
     on: settings['validateContactForm']})
 }}
+
+{{ forms.lightswitchField({
+    label: 'Validate user registration forms?',
+    instructions: 'Enable to automatically validate reCAPTCHAs when user registration forms are submitted.',
+    id: 'validateUserRegistrationForm',
+    name: 'validateUserRegistrationForm',
+    on: settings['validateUserRegistrationForm']})
+}}


### PR DESCRIPTION
Ok, after a few chats on craft-dev discord, this seems to be the best way to do this (checking the request is from the front end, and the the element (user) being created is new).

I haven't done anything in terms of version number .jsons etc, I never know if it's best to do that in these PRs or if you want to handle that yourself?

(Assuming you accept this, of course - but contact forms and user registrations are the two main places the spambots hit...)