### PR TITLE
Allow plugin to verify requests and forward them on to other controller actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ if ($validates) {
 }
 ```
 
+Or alternatively, use the in-built verification controller action to verify the request before forwarding it on to the intended action.
+
+For example, the following fields would verify the reCAPTCHA and then pass the request to the login controller action:
+
+```twig
+<input type="hidden" name="action" value="recaptcha/recaptcha/verify-submission">
+<input type="hidden" name="verified-action" value="users/login">
+{{ craft.recaptcha.render() }}
+```
+
+Set the `action` field to be `recaptcha/recaptcha/verify-submission` and the `verified-action` field to be the intended controller action you want to trigger. This will forward all other fields and parameters to the intended controller action.
+
 ### Automated testing and reCAPTCHA
 
 If you need to run automated tests against your forms use the following keys. Verification requests using these credentials will always pass.

--- a/src/controllers/RecaptchaController.php
+++ b/src/controllers/RecaptchaController.php
@@ -18,12 +18,12 @@ class RecaptchaController extends Controller
 	public function actionVerifySubmission()
 	{
 		// ensure the request is a post
-        $this->requirePostRequest();
-        
-        // grab the request object
-        $request = Craft::$app->getRequest();
-        
-        // grab the intended action (required)
+		$this->requirePostRequest();
+		
+		// grab the request object
+		$request = Craft::$app->getRequest();
+		
+		// grab the intended action (required)
 		$action = $request->getRequiredParam('verified-action');
 		
 		// grab the recaptcha response (required)
@@ -36,8 +36,8 @@ class RecaptchaController extends Controller
 		if ($verified) {
 			return Controller::run('/' . $action, func_get_args()); // run the intended action (add / to force it's scope to be outside the plugin) with all the params passed to this controller action
 		} else {
-            Craft::$app->getSession()->setError('Unable to verify your submission.');
-            return null;
+			Craft::$app->getSession()->setError('Unable to verify your submission.');
+			return null;
 		}
 	}
 }

--- a/src/controllers/RecaptchaController.php
+++ b/src/controllers/RecaptchaController.php
@@ -1,0 +1,43 @@
+<?php
+	
+namespace mattwest\craftrecaptcha\controllers;
+
+use mattwest\craftrecaptcha\CraftRecaptcha;
+
+use Craft;
+use craft\web\Controller;
+use yii\web\Response;
+
+class RecaptchaController extends Controller
+{
+	protected $allowAnonymous = true;
+	
+	/**
+	 * Handle verifying the submission and then pass it on to the relevant action (or not).
+	 */
+	public function actionVerifySubmission()
+	{
+		// ensure the request is a post
+        $this->requirePostRequest();
+        
+        // grab the request object
+        $request = Craft::$app->getRequest();
+        
+        // grab the intended action (required)
+		$action = $request->getRequiredParam('verified-action');
+		
+		// grab the recaptcha response (required)
+		$captcha = $request->getRequiredParam('g-recaptcha-response');
+		
+		// run these past the verify() function
+		$verified = CraftRecaptcha::$plugin->craftRecaptchaService->verify($captcha);
+		
+		// if it's verified, then pass it on to the intended action, otherwise set a session error and return null
+		if ($verified) {
+			return Controller::run('/' . $action, func_get_args()); // run the intended action (add / to force it's scope to be outside the plugin) with all the params passed to this controller action
+		} else {
+            Craft::$app->getSession()->setError('Unable to verify your submission.');
+            return null;
+		}
+	}
+}


### PR DESCRIPTION
This basically implements the code mentioned in the README inside a new controller, which performs the verification and then forwards the request to another controller action, using Yii's [`run()`](https://www.yiiframework.com/doc/api/2.0/yii-base-controller#run()-detail) method.

Would enable verifying registration submissions (making PR https://github.com/matt-west/craft-recaptcha/pull/12 unnecessary), as well as any other posted form submission, without needing to hook individual event types.