### PR TITLE
Update for Guzzle 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "craftcms/cms": "^3.1",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^6.3 || ^7.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This allows either Guzzle version to be installed.

As the Guzzle API has basically not changed and the use is so simple here, this is all that is needed...
