### PR TITLE
Include 'remoteip' with verify requests where possible

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -27,5 +27,6 @@ return [
     "siteKey" => "",
     "secretKey" => "",
     "validateContactForm" => true,
-    
+    "shareUserIPs" => false,
+
 ];

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -56,6 +56,13 @@ class Settings extends Model
      */
     public $validateContactForm = true;
 
+    /**
+     * Share user IP addresses with Google
+     *
+     * @var bool
+     */
+    public $shareUserIPs = false;
+
 
 
     // Public Methods

--- a/src/services/CraftRecaptchaService.php
+++ b/src/services/CraftRecaptchaService.php
@@ -70,6 +70,12 @@ class CraftRecaptchaService extends Component
           'response' => $data
       );
 
+      $ip = Craft::$app->getRequest()->userIP;
+
+      if ($ip) {
+          $params['remoteip'] = $ip;
+      }
+
       $client = new GuzzleHttp\Client();
       $response = $client->request('POST', $base, ['form_params' => $params]);
 

--- a/src/services/CraftRecaptchaService.php
+++ b/src/services/CraftRecaptchaService.php
@@ -70,10 +70,12 @@ class CraftRecaptchaService extends Component
           'response' => $data
       );
 
-      $ip = Craft::$app->getRequest()->userIP;
+      if ($settings->shareUserIPs) {
+        $ip = Craft::$app->getRequest()->userIP;
 
-      if ($ip) {
-          $params['remoteip'] = $ip;
+        if ($ip) {
+            $params['remoteip'] = $ip;
+        }
       }
 
       $client = new GuzzleHttp\Client();

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -45,3 +45,11 @@
     name: 'validateContactForm',
     on: settings['validateContactForm']})
 }}
+
+{{ forms.lightswitchField({
+    label: 'Share user IPs with Google?'|t('recaptcha'),
+    instructions: 'Enable to include requesting user IP addresses when making [siteverify](https://developers.google.com/recaptcha/docs/verify#api_request) requests.'|t('recaptcha'),
+    id: 'shareUserIPs',
+    name: 'shareUserIPs',
+    on: settings['shareUserIPs']})
+}}

--- a/src/translations/en/recaptcha.php
+++ b/src/translations/en/recaptcha.php
@@ -27,4 +27,5 @@ return [
     'Enter your reCAPTCHA site key.' => 'Enter your reCAPTCHA site key.',
     'Enter your reCAPTCHA secret key.' => 'Enter your reCAPTCHA secret key.',
     'Validate contact forms?' => 'Validate contact forms?',
+    'Share user IPs with Google?' => 'Share user IPs with Google?',
 ];


### PR DESCRIPTION
Google [don’t seem](https://developers.google.com/recaptcha/docs/verify#api_request) to publicly state what impact this has on verification requests, but quite a lot of spam seems to be getting through for me at the moment and this may well help in terms of filtering out requests from known malicious IPs. At worst it shouldn’t hurt (and I’ve omitted the var if Craft’s `userIP` is null).