### PR TITLE
Adds Support for v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Support for using reCAPTCHA v3 with v2 as a fallback.
+
 ## 1.5.3 - 2022-01-17
 ### Added
 - Added Italian translations. (Thanks [andreapasotti](https://github.com/matt-west/craft-recaptcha/pull/31)!)

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ Includes support for the CraftCMS [Contact Form](https://github.com/craftcms/con
 
 This plugin requires Craft CMS 3.1 or later.
 
-**This plugin supports reCAPTCHA v2 only.**
+**This plugin now supports reCAPTCHA v3 while still using v2 as a fallback!**
 
 ## Installation
 
-To install the plugin, follow these instructions.
+Install through the Craft plugin store.
+
+Alternatively, to install the plugin through your CLI, follow these instructions.
 
 1. Open your terminal and go to your Craft project:
 
@@ -25,23 +27,31 @@ To install the plugin, follow these instructions.
 
 ## Configuring Craft reCAPTCHA
 
-1. [Sign up for reCAPTCHA API key](https://www.google.com/recaptcha/admin).
+1. [Sign up for a v2 and v3 reCAPTCHA API key](https://www.google.com/recaptcha/admin).
 2. Open the Craft admin and go to Settings → Plugins → Craft reCAPTCHA → Settings.
-3. Add your `site key` and `secret key`, then save.
+3. Add your site keys and secret keys, then save.
 4. Add the reCAPTCHA template tag to your forms. (see next section)
 
-If you’re using the CraftCMS [Contact Form](https://github.com/craftcms/contact-form) plugin, everything is already set up for you.
+If you’re using the CraftCMS [Contact Form](https://github.com/craftcms/contact-form) plugin, verification is done automatically for you.
 
 ### Verify the reCAPTCHA
 
-To verify the reCAPTCHA is valid, pass the reCAPTCHA response from the `g-recaptcha-response` param to the `verify()` method on `CraftRecaptcha::$plugin->craftRecaptchaService`.
+To verify the reCAPTCHA is valid, check for either the reCAPTCHA response from the `recaptcha_response` (v3) or `g-recaptcha-response` (v2) param to the `verify()` method on `CraftRecaptcha::$plugin->craftRecaptchaService`.
 
 ```php
-// Get the reCAPTCHA response code to validate.
-$captcha = Craft::$app->getRequest()->getParam('g-recaptcha-response');
+use Craft;
+
+// See if a v3 response code is present
+$version = 3;
+$captcha = Craft::$app->getRequest()->getParam('recaptcha_response');
+if ($captcha === null) {
+  //if no v3 param exists, try v2
+  $version = 2;
+  $captcha = Craft::$app->getRequest()->getParam('g-recaptcha-response');
+}
 
 // Pass the response code to the verification service.
-$validates = CraftRecaptcha::$plugin->craftRecaptchaService->verify($captcha);
+$validates = CraftRecaptcha::$plugin->craftRecaptchaService->verify($captcha, $version, 'my-action', 0.5);
 
 if ($validates) {
   // All good! the reCAPTCHA is valid.
@@ -57,7 +67,11 @@ For example, the following fields would verify the reCAPTCHA and then pass the r
 ```twig
 <input type="hidden" name="action" value="recaptcha/recaptcha/verify-submission">
 <input type="hidden" name="verified-action" value="users/login">
-{{ craft.recaptcha.render() }}
+<input type="hidden" name="recaptcha-action" value="my-action">
+<input type="hidden" name="recaptcha-threshold" value="0.5">
+{{ craft.recaptcha.render({
+  recaptchaAction: 'my-action'
+}) }}
 ```
 
 Set the `action` field to be `recaptcha/recaptcha/verify-submission` and the `verified-action` field to be the intended controller action you want to trigger. This will forward all other fields and parameters to the intended controller action.
@@ -69,7 +83,7 @@ If you need to run automated tests against your forms use the following keys. Ve
 Site key: `6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI`
 Secret key: `6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe`
 
-[Documentation](https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha-v2-what-should-i-do)
+[Documentation](https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do)
 
 ## Using Craft reCAPTCHA
 
@@ -78,6 +92,8 @@ Add the following tag to your form where you’d like the reCAPTCHA to be displa
 ```twig
 {{ craft.recaptcha.render() }}
 ```
+
+The tag will automatically use a v3 reCAPTCHA on the first page load. If the verification fails, a v2 reCAPTCHA will be loaded instead.
 
 Render parameters [per the documentation](https://developers.google.com/recaptcha/docs/display#render_param) are injectable to the `render()` function, e.g.
 
@@ -88,14 +104,33 @@ Render parameters [per the documentation](https://developers.google.com/recaptch
 }) }}
 ```
 
-You can also create the reCAPTCHA element yourself using the `sitekey` template variable. This is especially useful for implementing invisible recaptcha.
+You can also create the reCAPTCHA element yourself using the `sitekey` and `sitekeyV3` template variables and the `recaptchaValid` param. This is especially useful for implementing invisible recaptcha.
 
 ```twig
-<div class="g-recaptcha"
-      data-sitekey="{{ craft.recaptcha.sitekey }}"
-      data-callback="onSubmit"
-      data-size="invisible">
-</div>
+{% if recaptchaValid is defined and recaptchaValid == false %}
+  {# a failed attempt has been made, use v2 #}
+  <div class="g-recaptcha" id="g-recaptcha-v2" data-size="invisible"></div>
+  {% js %}
+    var onloadCallback = function() {
+      grecaptcha.render(
+        document.getElementById('g-recaptcha-v2'),
+        {"sitekey": "{{ craft.recaptcha.sitekey }}", "theme": "dark"}
+      );
+    };
+  {% endjs  %}
+  {% do view.registerJsFile("https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit") %}
+{% else %}
+  {# no verification attempts yet, so use v3 #}
+  <input type="hidden" name="recaptcha_response" id="recaptchaResponse">
+  {% js %}
+    grecaptcha.ready(function() {
+      grecaptcha.execute('{{ craft.recaptcha.sitekeyV3 }}', {action: 'contact'}).then(function(token) {
+        var recaptchaResponse = document.getElementById('recaptchaResponse');
+        recaptchaResponse.value = token;
+      });
+    });
+  {% endjs %}
+{% endif %}
 ```
 
 ---

--- a/src/CraftRecaptcha.php
+++ b/src/CraftRecaptcha.php
@@ -48,7 +48,7 @@ class CraftRecaptcha extends Plugin
 {
     // Static Properties
     // =========================================================================
-
+    
     /**
      * Static property that is an instance of this plugin class so that it can be accessed via
      * CraftRecaptcha::$plugin
@@ -56,20 +56,20 @@ class CraftRecaptcha extends Plugin
      * @var CraftRecaptcha
      */
     public static $plugin;
-
+    
     // Public Properties
     // =========================================================================
-
+    
     /**
      * To execute your plugin’s migrations, you’ll need to increase its schema version.
      *
      * @var string
      */
     public $schemaVersion = '1.0.0';
-
+    
     // Public Methods
     // =========================================================================
-
+    
     /**
      * Set our $plugin static property to this class so that it can be accessed via
      * CraftRecaptcha::$plugin
@@ -85,7 +85,7 @@ class CraftRecaptcha extends Plugin
     {
         parent::init();
         self::$plugin = $this;
-
+        
         // Register our variables
         Event::on(
             CraftVariable::class,
@@ -96,7 +96,7 @@ class CraftRecaptcha extends Plugin
                 $variable->set('recaptcha', CraftRecaptchaVariable::class);
             }
         );
-
+        
         // Do something after we're installed
         Event::on(
             Plugins::class,
@@ -169,10 +169,10 @@ class CraftRecaptcha extends Plugin
             __METHOD__
         );
     }
-
+    
     // Protected Methods
     // =========================================================================
-
+    
     /**
      * Creates and returns the model used to store the plugin’s settings.
      *
@@ -182,7 +182,7 @@ class CraftRecaptcha extends Plugin
     {
         return new Settings();
     }
-
+    
     /**
      * Returns the rendered settings HTML, which will be inserted into the content
      * block on the settings page.

--- a/src/config.php
+++ b/src/config.php
@@ -23,9 +23,12 @@
  */
 
 return [
-
+    
     "siteKey" => "",
     "secretKey" => "",
+    "siteKeyV3" => "",
+    "secretKeyV3" => "",
+    "threshold" => "0.5",
     "validateContactForm" => true,
     "shareUserIPs" => false,
 

--- a/src/controllers/RecaptchaController.php
+++ b/src/controllers/RecaptchaController.php
@@ -26,17 +26,29 @@ class RecaptchaController extends Controller
 		// grab the intended action (required)
 		$action = $request->getRequiredParam('verified-action');
 		
-		// grab the recaptcha response (required)
-		$captcha = $request->getRequiredParam('g-recaptcha-response');
+		// grab the reCaptcha action
+		$reCaptchaAction = $request->getParam('recaptcha-action');
+
+		// grab the reCaptcha score threshold
+		$threshold = $request->getParam('recaptcha-threshold');
+
+		//Verify reCaptcha fields, first trying V3
+		$version = 3;
+		$captcha = Craft::$app->getRequest()->getParam('recaptcha_response');
+		if ($captcha === null) {
+			//no V3 param exists, try V2...
+			$version = 2;
+			$captcha = Craft::$app->getRequest()->getRequiredParam('g-recaptcha-response');
+		}
 		
 		// run these past the verify() function
-		$verified = CraftRecaptcha::$plugin->craftRecaptchaService->verify($captcha);
+		$verified = CraftRecaptcha::$plugin->craftRecaptchaService->verify($captcha, $version, $reCaptchaAction, $threshold);
 		
 		// if it's verified, then pass it on to the intended action, otherwise set a session error and return null
 		if ($verified) {
 			return Controller::run('/' . $action, func_get_args()); // run the intended action (add / to force it's scope to be outside the plugin) with all the params passed to this controller action
 		} else {
-            Craft::$app->getSession()->setError(Craft::t('site', 'Unable to verify your submission.'));
+			Craft::$app->getSession()->setError(Craft::t('site', 'Unable to verify your submission.'));
 			return null;
 		}
 	}

--- a/src/controllers/RecaptchaController.php
+++ b/src/controllers/RecaptchaController.php
@@ -1,5 +1,5 @@
 <?php
-	
+
 namespace mattwest\craftrecaptcha\controllers;
 
 use mattwest\craftrecaptcha\CraftRecaptcha;
@@ -10,46 +10,46 @@ use yii\web\Response;
 
 class RecaptchaController extends Controller
 {
-	protected $allowAnonymous = true;
-	
-	/**
-	 * Handle verifying the submission and then pass it on to the relevant action (or not).
-	 */
-	public function actionVerifySubmission()
-	{
-		// ensure the request is a post
-		$this->requirePostRequest();
-		
-		// grab the request object
-		$request = Craft::$app->getRequest();
-		
-		// grab the intended action (required)
-		$action = $request->getRequiredParam('verified-action');
-		
-		// grab the reCaptcha action
-		$reCaptchaAction = $request->getParam('recaptcha-action');
-
-		// grab the reCaptcha score threshold
-		$threshold = $request->getParam('recaptcha-threshold');
-
-		//Verify reCaptcha fields, first trying V3
-		$version = 3;
-		$captcha = Craft::$app->getRequest()->getParam('recaptcha_response');
-		if ($captcha === null) {
-			//no V3 param exists, try V2...
-			$version = 2;
-			$captcha = Craft::$app->getRequest()->getRequiredParam('g-recaptcha-response');
-		}
-		
-		// run these past the verify() function
-		$verified = CraftRecaptcha::$plugin->craftRecaptchaService->verify($captcha, $version, $reCaptchaAction, $threshold);
-		
-		// if it's verified, then pass it on to the intended action, otherwise set a session error and return null
-		if ($verified) {
-			return Controller::run('/' . $action, func_get_args()); // run the intended action (add / to force it's scope to be outside the plugin) with all the params passed to this controller action
-		} else {
-			Craft::$app->getSession()->setError(Craft::t('site', 'Unable to verify your submission.'));
-			return null;
-		}
-	}
+    protected $allowAnonymous = true;
+    
+    /**
+     * Handle verifying the submission and then pass it on to the relevant action (or not).
+     */
+    public function actionVerifySubmission()
+    {
+        // ensure the request is a post
+        $this->requirePostRequest();
+        
+        // grab the request object
+        $request = Craft::$app->getRequest();
+        
+        // grab the intended action (required)
+        $action = $request->getRequiredParam('verified-action');
+        
+        // grab the reCaptcha action
+        $reCaptchaAction = $request->getParam('recaptcha-action');
+        
+        // grab the reCaptcha score threshold
+        $threshold = $request->getParam('recaptcha-threshold');
+        
+        //Verify reCaptcha fields, first trying V3
+        $version = 3;
+        $captcha = Craft::$app->getRequest()->getParam('recaptcha_response');
+        if ($captcha === null) {
+            //no V3 param exists, try V2...
+            $version = 2;
+            $captcha = Craft::$app->getRequest()->getRequiredParam('g-recaptcha-response');
+        }
+        
+        // run these past the verify() function
+        $verified = CraftRecaptcha::$plugin->craftRecaptchaService->verify($captcha, $version, $reCaptchaAction, $threshold);
+        
+        // if it's verified, then pass it on to the intended action, otherwise set a session error and return null
+        if ($verified) {
+            return Controller::run('/' . $action, func_get_args()); // run the intended action (add / to force it's scope to be outside the plugin) with all the params passed to this controller action
+        } else {
+            Craft::$app->getSession()->setError(Craft::t('site', 'Unable to verify your submission.'));
+            return null;
+        }
+    }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -34,66 +34,111 @@ class Settings extends Model
 {
     // Public Properties
     // =========================================================================
-
+    
     /**
      * Site key model attribute
      *
      * @var string
      */
     public $siteKey = '';
-
+    
     /**
      * Secret key model attribute
      *
      * @var string
      */
     public $secretKey = '';
-
+    
+    /**
+     * v3 Site key model attribute
+     *
+     * @var string
+     */
+    public $siteKeyV3 = '';
+    
+    /**
+     * v3 Secret key model attribute
+     *
+     * @var string
+     */
+    public $secretKeyV3 = '';
+    
+    /**
+     * v3 response score threshold
+     *
+     * @var string
+     */
+    public $threshold = '';
+    
     /**
      * Validate ContactForm submissions
      *
      * @var bool
      */
     public $validateContactForm = true;
-
+    
     /**
      * Share user IP addresses with Google
      *
      * @var bool
      */
     public $shareUserIPs = false;
-
-
-
+    
+    
+    
     // Public Methods
     // =========================================================================
-
-  /**
-   * @return string the parsed site key (e.g. 'XXXXXXXXXXX')
-   */
-  public function getSiteKey(): string
-  {
-    return Craft::parseEnv($this->siteKey);
-  }
-
-  /**
-   * @return string the parsed secret key (e.g. 'XXXXXXXXXXX')
-   */
-  public function getSecretKey(): string
-  {
-    return Craft::parseEnv($this->secretKey);
-  }
-
-  public function behaviors()
-  {
-    return [
-        'parser' => [
-            'class' => EnvAttributeParserBehavior::class,
-            'attributes' => ['siteKey', 'secretKey'],
-        ],
-    ];
-  }
-
+    
+    /**
+     * @return string the parsed site key (e.g. 'XXXXXXXXXXX')
+     */
+    public function getSiteKey(): string
+    {
+        return Craft::parseEnv($this->siteKey);
+    }
+    
+    /**
+     * @return string the parsed secret key (e.g. 'XXXXXXXXXXX')
+     */
+    public function getSecretKey(): string
+    {
+        return Craft::parseEnv($this->secretKey);
+    }
+    
+    /**
+     * @return string the parsed v3 site key (e.g. 'XXXXXXXXXXX')
+     */
+    public function getSiteKeyV3(): string
+    {
+        return Craft::parseEnv($this->siteKeyV3);
+    }
+    
+    /**
+     * @return string the parsed v3 secret key (e.g. 'XXXXXXXXXXX')
+     */
+    public function getSecretKeyV3(): string
+    {
+        return Craft::parseEnv($this->secretKeyV3);
+    }
+    
+    /**
+     * @return float the v3 response score threshold (e.g. '0.5')
+     */
+    public function getThreshold(): float
+    {
+        return floatval($this->threshold);
+    }
+    
+    public function behaviors()
+    {
+        return [
+            'parser' => [
+                'class' => EnvAttributeParserBehavior::class,
+                'attributes' => ['siteKey', 'secretKey', 'siteKeyV3', 'secretKeyV3'],
+            ],
+        ];
+    }
+    
     /**
      * Returns the validation rules for attributes.
      *
@@ -109,6 +154,9 @@ class Settings extends Model
         return [
             ['siteKey', 'string'],
             ['secretKey', 'string'],
+            ['siteKeyV3', 'string'],
+            ['secretKeyV3', 'string'],
+            ['threshold', 'string'],
             [['siteKey', 'secretKey'], 'required']
         ];
     }

--- a/src/services/CraftRecaptchaService.php
+++ b/src/services/CraftRecaptchaService.php
@@ -34,65 +34,85 @@ class CraftRecaptchaService extends Component
 {
     // Public Methods
     // =========================================================================
-
+    
     public function render(array $options = [])
     {
+        $routeParams = Craft::$app->getUrlManager()->getRouteParams();
         $settings = CraftRecaptcha::$plugin->getSettings();
-        $currentLanguage = (\Craft::$app->getSites()->getCurrentSite()->language)? \Craft::$app->getSites()->getCurrentSite()->language :'en' ;
-        \Craft::$app->view->registerJsFile('https://www.google.com/recaptcha/api.js?&hl='. $currentLanguage);
-
+        $currentLanguage = (Craft::$app->getSites()->getCurrentSite()->language) ? Craft::$app->getSites()->getCurrentSite()->language :'en' ;
+        
+        if($settings->getSiteKeyV3() && !isset($routeParams['variables']['recaptchaValid'])){
+            Craft::$app->view->registerJsFile('https://www.google.com/recaptcha/api.js?render='. $settings->getSiteKeyV3() .'&hl='. $currentLanguage);
+        }
+        else{
+            Craft::$app->view->registerJsFile('https://www.google.com/recaptcha/api.js?&hl='. $currentLanguage);
+        }
+        
         $defaultOptions = [
-            'siteKey' => $settings->getSiteKey()
+            'siteKey' => $settings->getSiteKey(),
+            'siteKeyV3' => $settings->getSiteKeyV3(),
+            'recaptchaAction' => 'contact'
         ];
-
+        
         $vars = array(
             'id' => 'gRecaptchaContainer',
             'options' => array_merge($defaultOptions, $options)
         );
-
-        $oldMode = \Craft::$app->view->getTemplateMode();
-        \Craft::$app->view->setTemplateMode(View::TEMPLATE_MODE_CP);
-
-        $html = \Craft::$app->view->renderTemplate('recaptcha/_recaptcha', $vars);
-
-        \Craft::$app->view->setTemplateMode($oldMode);
-
+        if(isset($routeParams['variables']['recaptchaValid'])) $vars['recaptchaValid'] = $routeParams['variables']['recaptchaValid'];
+        
+        $oldMode = Craft::$app->view->getTemplateMode();
+        Craft::$app->view->setTemplateMode(View::TEMPLATE_MODE_CP);
+        
+        $html = Craft::$app->view->renderTemplate('recaptcha/_recaptcha', $vars);
+        
+        Craft::$app->view->setTemplateMode($oldMode);
+        
         echo $html;
     }
-
-    public function verify($data)
+    
+    public function verify($data, $version, $action = '', $threshold)
     {
-      $base = "https://www.google.com/recaptcha/api/siteverify";
-
-      $settings = CraftRecaptcha::$plugin->getSettings();
-      $params = array(
-          'secret' =>  $settings->getSecretKey(),
-          'response' => $data
-      );
-
-      if ($settings->shareUserIPs) {
-        $ip = Craft::$app->getRequest()->userIP;
-
-        if ($ip) {
-            $params['remoteip'] = $ip;
+        $base = "https://www.google.com/recaptcha/api/siteverify";
+        
+        $settings = CraftRecaptcha::$plugin->getSettings();
+        
+        $secret = $version === 3 ? $settings->getSecretKeyV3() : $settings->getSecretKey();
+        
+        $params = array(
+            'secret' =>  $secret,
+            'response' => $data
+        );
+        
+        if ($settings->shareUserIPs) {
+            $ip = Craft::$app->getRequest()->userIP;
+            
+            if ($ip) {
+                $params['remoteip'] = $ip;
+            }
         }
-      }
-
-      $client = new GuzzleHttp\Client();
-      $response = $client->request('POST', $base, ['form_params' => $params]);
-
-      if($response->getStatusCode() == 200)
-      {
-          $json = json_decode($response->getBody());
-
-          if($json->success)
-          {
-              return true;
-          } else {
-              return false;
-          }
-      } else {
-          return false;
-      }
+        
+        $client = new GuzzleHttp\Client();
+        
+        $response = $client->request('POST', $base, ['form_params' => $params]);
+        $valid = false;
+        if($response->getStatusCode() == 200)
+        {
+            $json = json_decode($response->getBody());
+            
+            if($json->success)
+            {
+                // Take action based on the score returned if v3
+                if($version === 3){
+                    if(($action ? $json->action === $action : true) && 0.5 >= floatval($threshold)) {
+                        $valid = true;
+                    }
+                }
+                else $valid = true;
+            }
+        }
+        Craft::$app->getUrlManager()->setRouteParams([
+            'variables' => ['recaptchaValid' => $valid]
+        ]);
+        return $valid;
     }
 }

--- a/src/services/CraftRecaptchaService.php
+++ b/src/services/CraftRecaptchaService.php
@@ -70,7 +70,15 @@ class CraftRecaptchaService extends Component
         echo $html;
     }
     
-    public function verify($data, $version, $action = '', $threshold)
+    /**
+     * @param string $data
+     * @param integer $version Either 2 or 3
+     * @param string $action See https://developers.google.com/recaptcha/docs/v3#actions
+     * @param float|string $threshold See https://developers.google.com/recaptcha/docs/v3#interpreting_the_score
+     * @return bool
+     * @throws GuzzleHttp\Exception\GuzzleException
+     */
+    public function verify(string $data, int $version, string $action = '', $threshold = 0.5)
     {
         $base = "https://www.google.com/recaptcha/api/siteverify";
         

--- a/src/templates/_recaptcha.twig
+++ b/src/templates/_recaptcha.twig
@@ -1,1 +1,15 @@
-<div class="g-recaptcha" id="{{id}}" {% for key, value in options %}data-{{ key }}="{{ value }}" {% endfor %}></div>
+{% if(options.siteKeyV3 is not empty and recaptchaValid is not defined) %}
+    {# a V3 site key is available and a verify attempt has not yet been made #}
+    <input type="hidden" name="recaptcha_response" id="recaptchaV3Response">
+    {% js %}
+        grecaptcha.ready(function() {
+            grecaptcha.execute('{{ options.siteKeyV3 }}', {action: '{{ options.recaptchaAction }}'}).then(function(token) {
+                var recaptchaResponse = document.getElementById('recaptchaV3Response');
+                recaptchaResponse.value = token;
+            });
+        });
+    {% endjs  %}
+{% else %}
+    {# either no V3 site key or a verify attempt has been made and failed #}
+    <div class="g-recaptcha" id="{{id}}" {% for key, value in options %}data-{{ key }}="{{ value }}" {% endfor %}></div>
+{% endif %}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -55,15 +55,26 @@
     suggestEnvVars: true})
 }}
 
-{{ forms.textField({
+{{ forms.selectField({
     label: 'v3 Score Threshold'|t('recaptcha'),
-    instructions: 'Enter the threshold (value between 0.0 - 1.0) that should determine whether the response score is rejected.'|t('recaptcha'),
+    instructions: 'Enter your reCAPTCHA threshold preference.'|t('recaptcha'),
     id: 'threshold',
     name: 'threshold',
     value: settings['threshold'],
-    size: 'halfwidth',
-    required: false})
-}}
+    options: [
+        { value: '0.0', label: '0.0' },
+        { value: '0.1', label: '0.1' },
+        { value: '0.2', label: '0.2' },
+        { value: '0.3', label: '0.3' },
+        { value: '0.4', label: '0.4' },
+        { value: '0.5', label: '0.5' },
+        { value: '0.6', label: '0.6' },
+        { value: '0.7', label: '0.7' },
+        { value: '0.8', label: '0.8' },
+        { value: '0.9', label: '0.9' },
+        { value: '1.0', label: '1.0' }
+    ]
+}) }}
 
 
 <hr>

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -35,6 +35,36 @@
     suggestEnvVars: true})
 }}
 
+{{ forms.autosuggestField({
+    label: 'Site Key v3'|t('recaptcha'),
+    instructions: 'Enter your v3 reCAPTCHA site key.'|t('recaptcha'),
+    id: 'siteKeyV3',
+    name: 'siteKeyV3',
+    value: settings['siteKeyV3'],
+    required: false,
+    suggestEnvVars: true})
+}}
+
+{{ forms.autosuggestField({
+    label: 'Secret Key v3'|t('recaptcha'),
+    instructions: 'Enter your v3 reCAPTCHA secret key.'|t('recaptcha'),
+    id: 'secretKeyV3',
+    name: 'secretKeyV3',
+    value: settings['secretKeyV3'],
+    required: false,
+    suggestEnvVars: true})
+}}
+
+{{ forms.textField({
+    label: 'v3 Score Threshold'|t('recaptcha'),
+    instructions: 'Enter the threshold (value between 0.0 - 1.0) that should determine whether the response score is rejected.'|t('recaptcha'),
+    id: 'threshold',
+    name: 'threshold',
+    value: settings['threshold'],
+    size: 'halfwidth',
+    required: false})
+}}
+
 
 <hr>
 

--- a/src/variables/CraftRecaptchaVariable.php
+++ b/src/variables/CraftRecaptchaVariable.php
@@ -30,7 +30,7 @@ class CraftRecaptchaVariable
 {
     // Public Methods
     // =========================================================================
-
+    
     /**
      * Render the reCAPTCHA widget.
      *

--- a/src/variables/CraftRecaptchaVariable.php
+++ b/src/variables/CraftRecaptchaVariable.php
@@ -41,13 +41,20 @@ class CraftRecaptchaVariable
      */
     public function render(array $options = [])
     {
-      return CraftRecaptcha::$plugin->craftRecaptchaService->render($options);
+        return CraftRecaptcha::$plugin->craftRecaptchaService->render($options);
     }
-
+    
     public function sitekey()
     {
-      $settings = CraftRecaptcha::$plugin->getSettings();
-
-      return $settings->getSiteKey();
+        $settings = CraftRecaptcha::$plugin->getSettings();
+        
+        return $settings->getSiteKey();
+    }
+    
+    public function sitekeyV3()
+    {
+        $settings = CraftRecaptcha::$plugin->getSettings();
+        
+        return $settings->getSiteKeyV3();
     }
 }


### PR DESCRIPTION
This PR adds support for v3. Essentially the `verify` service now will check for v3 response param first, if it doesn't find it, it uses v2 params. The render, settings, and controller functions have also been modified to handle this. I have used this approach on several of my other sites. 

The advantage is that a v3 captcha is used on the first form submission, meaning no 'captcha' challenge for the user. If, for some reason, that captcha fails, a v2 challenge captcha is shown.